### PR TITLE
Use ssl issue 203

### DIFF
--- a/ad-ldap/1.0.0/api.yaml
+++ b/ad-ldap/1.0.0/api.yaml
@@ -1,4 +1,4 @@
-app_version: 1.0.0
+app_version: 1.0.1
 name: AD LDAP 
 description: A simple app to query Active Directory and LDAP
 contact_info:

--- a/ad-ldap/1.0.0/src/app.py
+++ b/ad-ldap/1.0.0/src/app.py
@@ -6,7 +6,7 @@ from walkoff_app_sdk.app_base import AppBase
 
 
 class ADLDAP(AppBase):
-    __version__ = "1.0.0"
+    __version__ = "1.0.1"
     app_name = "AD LDAP"  # this needs to match "name" in api.yaml
 
     def __init__(self, redis, logger, console_logger=None):
@@ -23,6 +23,7 @@ class ADLDAP(AppBase):
 
         user = '{}\\{}'.format(domain_name, user_name)
         port = int(port)
+        use_ssl = False if use_ssl.lower() == "false" else True
 
         conn = Connection(Server(server_name, port=port, use_ssl=use_ssl), auto_bind=AUTO_BIND_NO_TLS, user=user, password=password)
 


### PR DESCRIPTION
Fixes #203 
YAML true/false option from app.yaml passes incorrect type to search_samaccountname() function causing an SSL error when use_ssl=false. Casting use_ssl fixes the problem.